### PR TITLE
test: verify Sonny identity in GitHub PR

### DIFF
--- a/SONNY_IDENTITY_TEST.md
+++ b/SONNY_IDENTITY_TEST.md
@@ -1,0 +1,13 @@
+# Sonny Identity Verification
+
+This PR verifies that commits and PRs are now showing under modscanner-sonny identity instead of Aziz.
+
+## Test Details
+- SSH remote configured to use github-sonny alias
+- Authentication confirmed: 'Hi modscanner-sonny!'
+- This commit should appear under Sonny's GitHub account
+
+## Expected Result
+- PR author: modscanner-sonny
+- Commit author: modscanner-sonny
+- No more Aziz identity in Git operations


### PR DESCRIPTION
This PR verifies that commits and PRs are now showing under modscanner-sonny identity instead of Aziz.

## Test Details
- SSH remote configured to use github-sonny alias
- Authentication confirmed: 'Hi modscanner-sonny!'
- This commit should appear under Sonny's GitHub account

## Expected Result
- PR author: modscanner-sonny
- Commit author: modscanner-sonny
- No more Aziz identity in Git operations

## Reviewer Assignment
- Assigning Amy to review this identity verification test